### PR TITLE
Cast n value to NSNumber type

### DIFF
--- a/OmiseSwift/Int64Converter.swift
+++ b/OmiseSwift/Int64Converter.swift
@@ -10,6 +10,6 @@ public class Int64Converter: Converter {
     
     public static func convert(fromValue value: Target?) -> Any? {
         guard let n = value else { return nil }
-        return n
+        return NSNumber(value: n)
     }
 }


### PR DESCRIPTION
Cast value in Int64Converter to NSNumber type because it return nil when we set value
