### PR TITLE
Fixed: The converter and NSNumber compatiblity

### DIFF
--- a/OmiseSwift/DateComponentsConverter.swift
+++ b/OmiseSwift/DateComponentsConverter.swift
@@ -52,7 +52,8 @@ public class DateComponentsConverter: Converter {
     
     public static func convert(fromValue value: Target?) -> Any? {
         guard let dateComponents = value,
-            (dateComponents.calendar?.identifier ?? Calendar.current.identifier) == .gregorian else { return nil }
-        return "\(dateComponents.year)-\(dateComponents.month)-\(dateComponents.day)" as NSString
+            (dateComponents.calendar?.identifier ?? Calendar.current.identifier) == .gregorian,
+        let year = dateComponents.year, let month = dateComponents.month, let day = dateComponents.day else { return nil }
+        return "\(year)-\(month)-\(day)"
     }
 }

--- a/OmiseSwift/Int64Converter.swift
+++ b/OmiseSwift/Int64Converter.swift
@@ -16,6 +16,6 @@ public class Int64Converter: Converter {
     
     public static func convert(fromValue value: Target?) -> Any? {
         guard let n = value else { return nil }
-        return NSNumber(value: n)
+        return n
     }
 }

--- a/OmiseSwiftTests/URLEncoderTest.swift
+++ b/OmiseSwiftTests/URLEncoderTest.swift
@@ -48,4 +48,20 @@ class URLEncoderTest: OmiseTestCase {
         XCTAssertEqual("2deeper[nesting][also]", result[2].name)
         XCTAssertEqual("works", result[2].value)
     }
+    
+    func testConverter() {
+        let searchFilterParams = ChargeFilterParams()
+        searchFilterParams.amount = 1000
+        searchFilterParams.cardLastDigits = "4242"
+        searchFilterParams.capture = true
+        searchFilterParams.created = DateComponents(year: 2016, month: 8, day: 1)
+        
+        let result = Set(URLEncoder.encode(searchFilterParams.normalizedAttributes).map({ (query) in query.value ?? "(nil)" }))
+        XCTAssertEqual(result, [
+            "1000",
+            "4242",
+            "true",
+            "2016-8-1"
+            ])
+    }
 }


### PR DESCRIPTION
The behavior of the auto boxing to/from NSNumber was change in Swift 3.0.1
This PR update our code to match the new behavior